### PR TITLE
Remove positional parameters from i18n.merge_file

### DIFF
--- a/data/appdata/meson.build
+++ b/data/appdata/meson.build
@@ -26,7 +26,7 @@ foreach metainfo : metainfos
         output: metainfo + '.in',
         configuration: data_config,
     )
-    i18n.merge_file(metainfo,
+    i18n.merge_file(
         input:  metainfo_in,
         output: metainfo,
         install: true,

--- a/data/caja/meson.build
+++ b/data/caja/meson.build
@@ -7,7 +7,7 @@ cajaextension_in = configure_file(
     configuration: data_config,
 )
 
-i18n.merge_file(cajaextension,
+i18n.merge_file(
     input:  cajaextension_in,
     output: cajaextension,
     install: true,


### PR DESCRIPTION
As per https://github.com/mesonbuild/meson/issues/9441,
these arguments were never used and were made deprecated in Meson 60.