### PR TITLE
Fix build with Nettle 4 by using version macros

### DIFF
--- a/src/hash/hash-lib-nettle.c
+++ b/src/hash/hash-lib-nettle.c
@@ -27,6 +27,7 @@
 #include <glib.h>
 #include <nettle/nettle-meta.h>
 #include <nettle/sha3.h>
+#include <nettle/version.h>
 
 #include "hash-lib.h"
 #include "hash-func.h"
@@ -103,7 +104,11 @@ uint8_t *gtkhash_hash_lib_nettle_finish(struct hash_func_s *func,
 	*size = LIB_DATA->meta->digest_size;
 	uint8_t *digest = g_malloc(*size);
 
+#if NETTLE_VERSION_MAJOR >= 4
+	LIB_DATA->meta->digest(LIB_DATA->ctx, digest);
+#else
 	LIB_DATA->meta->digest(LIB_DATA->ctx, *size, digest);
+#endif
 
 	g_free(LIB_DATA->ctx);
 	g_free(LIB_DATA);


### PR DESCRIPTION
Nettle 4 changed the digest function signature, removing the length parameter. Add an include for nettle/version.h and use NETTLE_VERSION_MAJOR to conditionally compile the correct call, ensuring compatibility with both Nettle 3.x and 4.x.

This resolves build failures on systems where Nettle 4 is the default (e.g., recent Manjaro).